### PR TITLE
Torchtext 0.12 fixes

### DIFF
--- a/training-job/bert.py
+++ b/training-job/bert.py
@@ -27,12 +27,6 @@ from torchtext.datasets import AG_NEWS
 from transformers import BertModel, BertTokenizer, AdamW
 
 
-def get_20newsgroups(num_samples):
-    categories = ["alt.atheism", "talk.religion.misc", "comp.graphics", "sci.space"]
-    X, y = fetch_20newsgroups(subset="train", categories=categories, return_X_y=True)
-    return pd.DataFrame(data=X, columns=["description"]).assign(label=y).sample(n=num_samples)
-
-
 class NewsDataset(IterDataPipe):
     def __init__(self, tokenizer, source_datapipe, max_length, num_samples=None):
         super(NewsDataset, self).__init__()
@@ -388,30 +382,23 @@ if __name__ == "__main__":
     parser.add_argument(
         "--train_num_samples",
         type=int,
-        default=1000,
+        default=10000,
         metavar="N",
         help="Number of samples to be used for training",
     )
     parser.add_argument(
         "--val_num_samples",
         type=int,
-        default=100,
+        default=1000,
         metavar="N",
         help="Number of samples to be used for validation",
     )
     parser.add_argument(
         "--test_num_samples",
         type=int,
-        default=200,
+        default=1000,
         metavar="N",
         help="Number of samples to be used for testing",
-    )
-    parser.add_argument(
-        "--dataset",
-        default="20newsgroups",
-        metavar="DATASET",
-        help="Dataset to use",
-        choices=["20newsgroups", "ag_news"],
     )
 
     parser.add_argument(
@@ -463,7 +450,6 @@ if __name__ == "__main__":
                 callbacks=[lr_logger, early_stopping, checkpoint_callback],
                 resume_from_checkpoint=checkpoint_list[0],
                 checkpoint_callback=True,
-                # val_check_interval=0.2
             )
     else:
         trainer = pl.Trainer.from_argparse_args(

--- a/training-job/bert.py
+++ b/training-job/bert.py
@@ -236,11 +236,7 @@ class BertNewsClassifier(pl.LightningModule):
             param.requires_grad = False
         self.drop = nn.Dropout(p=0.2)
         # assigning labels
-        self.class_names = (
-            ["alt.atheism", "talk.religion.misc", "comp.graphics", "sci.space"]
-            if kwargs["dataset"] == "20newsgroups"
-            else ["world", "Sports", "Business", "Sci/Tech"]
-        )
+        self.class_names = ["world", "Sports", "Business", "Sci/Tech"]
         n_classes = len(self.class_names)
 
         self.fc1 = nn.Linear(self.bert_model.config.hidden_size, 512)
@@ -382,21 +378,21 @@ if __name__ == "__main__":
     parser.add_argument(
         "--train_num_samples",
         type=int,
-        default=10000,
+        default=2000,
         metavar="N",
         help="Number of samples to be used for training",
     )
     parser.add_argument(
         "--val_num_samples",
         type=int,
-        default=1000,
+        default=200,
         metavar="N",
         help="Number of samples to be used for validation",
     )
     parser.add_argument(
         "--test_num_samples",
         type=int,
-        default=1000,
+        default=200,
         metavar="N",
         help="Number of samples to be used for testing",
     )

--- a/training-job/bert.slurm
+++ b/training-job/bert.slurm
@@ -39,5 +39,5 @@ export NCCL_SOCKET_IFNAME="en,eth,em,bond"
 
 ### the command to run
 dcgmi profile --pause
-srun --prolog job_prolog.sh --epilog job_epilog.sh /usr/local/cuda/bin/nsys profile -t cuda,nvtx -s none -x true python bert.py --dataset="ag_news" --strategy=ddp --num_nodes=2 --gpus=8 --num_samples=2000 --max_epochs=15
+srun --prolog job_prolog.sh --epilog job_epilog.sh /usr/local/cuda/bin/nsys profile -t cuda,nvtx -s none -x true python bert.py --strategy=ddp --num_nodes=2 --gpus=8 --max_epochs=15
 dcgmi profile --resume

--- a/training-job/requirements.txt
+++ b/training-job/requirements.txt
@@ -3,3 +3,4 @@ pandas
 sklearn
 pytorch_lightning
 transformers
+torchdata


### PR DESCRIPTION
Torchtext - 0.12.0 - https://pypi.org/project/torchtext/0.12.0/ has been released. 

The previous version of torchtext downloads the agnews csv file and the user has to load the data.

However, latest version (0.12.0) uses data pipes - https://github.com/pytorch/data#what-are-datapipes .

Updated the bert example to work with latest version of torchtext.

Logs:

CPU -
[bert_cpu.txt](https://github.com/chauhang/uber-prof/files/8256422/bert_cpu.txt)

1 GPU - 
[bert_single_gpu.txt](https://github.com/chauhang/uber-prof/files/8256424/bert_single_gpu.txt)

Multi gpu DDP - 
[bert_multigpu.txt](https://github.com/chauhang/uber-prof/files/8256427/bert_multigpu.txt)
 
Slurm cluster
[bert_cluster.txt](https://github.com/chauhang/uber-prof/files/8270100/bert_cluster.txt)

