### PR TITLE
Linking test error injection log to README.md 

### DIFF
--- a/training-job/README.md
+++ b/training-job/README.md
@@ -169,3 +169,7 @@ To run the test in debug mode - run the following command
 ```
 pytest -sv --log-cli-level=DEBUG test_error_injection.py 
 ```
+
+Sample log output
+
+<script src="https://gist.github.com/shrinath-suresh/c738c28cf28cf5ecae6de2eb25035cce"></script> 

--- a/training-job/README.md
+++ b/training-job/README.md
@@ -170,6 +170,4 @@ To run the test in debug mode - run the following command
 pytest -sv --log-cli-level=DEBUG test_error_injection.py 
 ```
 
-Sample log output
-
-<script src="https://gist.github.com/shrinath-suresh/c738c28cf28cf5ecae6de2eb25035cce"></script> 
+Sample log output - [here](https://gist.github.com/shrinath-suresh/c738c28cf28cf5ecae6de2eb25035cce)


### PR DESCRIPTION
Linking test error injection script output in README.md file - https://gist.github.com/shrinath-suresh/c738c28cf28cf5ecae6de2eb25035cce