### PR TITLE
Adding mnist fsdp example

### DIFF
--- a/training-job/mnist.md
+++ b/training-job/mnist.md
@@ -1,0 +1,67 @@
+# Run a training slurm job
+
+PyTorch Fully Sharded Data Parallel - https://pytorch.org/tutorials/intermediate/FSDP_tutorial.html 
+
+This example trains MNIST dataset using PyTorch FSDP in a distributed environment
+
+The distributed training process is achieved using SLURM and Pytorch Elastic.
+
+
+## Run job
+
+```bash
+# Add executable permission to files if needed
+chmod +x job_prolog.sh
+chmod +x job_epilog.sh
+```
+
+Start the slurm job
+
+```bash
+sbatch mnist.slurm
+```
+
+## Sample log
+
+```
+Train Epoch: 1 	Loss: 0.252124
+Train Epoch: 1 	Loss: 0.252124
+Test set: Average loss: 0.0492, Accuracy: 9834/10000 (98.34%)
+
+Test set: Average loss: 0.0492, Accuracy: 9834/10000 (98.34%)
+
+Train Epoch: 2 	Loss: 0.072150
+Train Epoch: 2 	Loss: 0.072164
+Test set: Average loss: 0.0367, Accuracy: 9882/10000 (98.82%)
+
+Cuda event elapsed time: 80.0649453125sec
+FullyShardedDataParallel(
+  (_fsdp_wrapped_module): FlattenParamsWrapper(
+    (_fpw_module): Net(
+      (conv1): Conv2d(1, 32, kernel_size=(3, 3), stride=(1, 1))
+      (conv2): Conv2d(32, 64, kernel_size=(3, 3), stride=(1, 1))
+      (dropout1): Dropout(p=0.25, inplace=False)
+      (dropout2): Dropout(p=0.5, inplace=False)
+      (fc1): Linear(in_features=9216, out_features=128, bias=True)
+      (fc2): Linear(in_features=128, out_features=10, bias=True)
+    )
+  )
+)
+Test set: Average loss: 0.0370, Accuracy: 9880/10000 (98.80%)
+
+Cuda event elapsed time: 80.628984375sec
+FullyShardedDataParallel(
+  (_fsdp_wrapped_module): FlattenParamsWrapper(
+    (_fpw_module): Net(
+      (conv1): Conv2d(1, 32, kernel_size=(3, 3), stride=(1, 1))
+      (conv2): Conv2d(32, 64, kernel_size=(3, 3), stride=(1, 1))
+      (dropout1): Dropout(p=0.25, inplace=False)
+      (dropout2): Dropout(p=0.5, inplace=False)
+      (fc1): Linear(in_features=9216, out_features=128, bias=True)
+      (fc2): Linear(in_features=128, out_features=10, bias=True)
+    )
+  )
+)
+
+```
+

--- a/training-job/mnist.slurm
+++ b/training-job/mnist.slurm
@@ -2,42 +2,11 @@
 ### e.g. request 4 nodes with 1 gpu each, totally 4 gpus (WORLD_SIZE==4)
 ### Note: --gres=gpu:x should equal to ntasks-per-node
 #SBATCH --nodes=2
-#SBATCH --ntasks-per-node=8
-#SBATCH --gres=gpu:8
 #SBATCH --mem=0
 #SBATCH --signal=SIGUSR1@90
 
-### change 5-digit MASTER_PORT as you wish, slurm will raise Error if duplicated with others
-### change WORLD_SIZE as gpus/node * num_nodes
-export MASTER_PORT=12356
-echo "MASTER_PORT="$MASTER_PORT
-export WORLD_SIZE=32
-### get the first node name as master address - customized for vgg slurm
-### e.g. master(gnodee[2-5],gnoded1) == gnodee2
-echo "NODELIST="${SLURM_NODELIST}
-master_addr=$(scontrol show hostnames "$SLURM_JOB_NODELIST" | head -n 1)
-export MASTER_ADDR=$master_addr
-echo "MASTER_ADDR="$MASTER_ADDR
-
-# debugging flags (optional)
-#export NCCL_DEBUG=INFO
-#export NCCL_DEBUG_SUBSYS=ALL
-#export PYTHONFAULTHANDLER=1
-
-export FI_PROVIDER="efa"
-
-export LD_LIBRARY_PATH=/opt/amazon/efa/lib:$LD_LIBRARY_PATH
-export LD_LIBRARY_PATH=/usr/local/lib/:$LD_LIBRARY_PATH
-
-# on your cluster you might need these:
-# set the network interface
-export NCCL_SOCKET_IFNAME="en,eth,em,bond"
-
-# uncommet for using IP sockets
-# export NCCL_IB_DISABLE=1
-# export NCCL_P2P_DISABLE=1
 
 ### the command to run
 dcgmi profile --pause
-srun --prolog job_prolog.sh --epilog job_epilog.sh /usr/local/cuda/bin/nsys profile -t cuda,nvtx -s none -x true python mnist_fsdp.py
+srun --prolog job_prolog.sh --epilog job_epilog.sh /usr/local/cuda/bin/nsys profile -t cuda,nvtx -s none -x true torchrun  --nproc_per_node=4 mnist_fsdp.py
 dcgmi profile --resume

--- a/training-job/mnist.slurm
+++ b/training-job/mnist.slurm
@@ -39,5 +39,5 @@ export NCCL_SOCKET_IFNAME="en,eth,em,bond"
 
 ### the command to run
 dcgmi profile --pause
-srun --prolog job_prolog.sh --epilog job_epilog.sh /usr/local/cuda/bin/nsys profile -t cuda,nvtx -s none -x true python fsdp.py
+srun --prolog job_prolog.sh --epilog job_epilog.sh /usr/local/cuda/bin/nsys profile -t cuda,nvtx -s none -x true python mnist_fsdp.py
 dcgmi profile --resume

--- a/training-job/mnist.slurm
+++ b/training-job/mnist.slurm
@@ -1,0 +1,43 @@
+#!/bin/bash -l
+### e.g. request 4 nodes with 1 gpu each, totally 4 gpus (WORLD_SIZE==4)
+### Note: --gres=gpu:x should equal to ntasks-per-node
+#SBATCH --nodes=2
+#SBATCH --ntasks-per-node=8
+#SBATCH --gres=gpu:8
+#SBATCH --mem=0
+#SBATCH --signal=SIGUSR1@90
+
+### change 5-digit MASTER_PORT as you wish, slurm will raise Error if duplicated with others
+### change WORLD_SIZE as gpus/node * num_nodes
+export MASTER_PORT=12356
+echo "MASTER_PORT="$MASTER_PORT
+export WORLD_SIZE=32
+### get the first node name as master address - customized for vgg slurm
+### e.g. master(gnodee[2-5],gnoded1) == gnodee2
+echo "NODELIST="${SLURM_NODELIST}
+master_addr=$(scontrol show hostnames "$SLURM_JOB_NODELIST" | head -n 1)
+export MASTER_ADDR=$master_addr
+echo "MASTER_ADDR="$MASTER_ADDR
+
+# debugging flags (optional)
+#export NCCL_DEBUG=INFO
+#export NCCL_DEBUG_SUBSYS=ALL
+#export PYTHONFAULTHANDLER=1
+
+export FI_PROVIDER="efa"
+
+export LD_LIBRARY_PATH=/opt/amazon/efa/lib:$LD_LIBRARY_PATH
+export LD_LIBRARY_PATH=/usr/local/lib/:$LD_LIBRARY_PATH
+
+# on your cluster you might need these:
+# set the network interface
+export NCCL_SOCKET_IFNAME="en,eth,em,bond"
+
+# uncommet for using IP sockets
+# export NCCL_IB_DISABLE=1
+# export NCCL_P2P_DISABLE=1
+
+### the command to run
+dcgmi profile --pause
+srun --prolog job_prolog.sh --epilog job_epilog.sh /usr/local/cuda/bin/nsys profile -t cuda,nvtx -s none -x true python fsdp.py
+dcgmi profile --resume

--- a/training-job/mnist_fsdp.py
+++ b/training-job/mnist_fsdp.py
@@ -1,0 +1,195 @@
+# Based on: https://github.com/pytorch/examples/blob/master/mnist/main.py
+import argparse
+import functools
+import os
+
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+import torch.nn as nn
+import torch.nn.functional as F
+import torch.optim as optim
+# from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
+from torch.distributed.fsdp.fully_sharded_data_parallel import (
+    FullyShardedDataParallel as FSDP,
+)
+from torch.distributed.fsdp.wrap import (
+    default_auto_wrap_policy,
+)
+from torch.optim.lr_scheduler import StepLR
+from torch.utils.data.distributed import DistributedSampler
+from torchvision import datasets, transforms
+
+
+def setup(rank, world_size):
+    os.environ['MASTER_ADDR'] = 'localhost'
+    os.environ['MASTER_PORT'] = '12355'
+
+    # initialize the process group
+    dist.init_process_group("nccl", rank=rank, world_size=world_size)
+
+
+def cleanup():
+    dist.destroy_process_group()
+
+
+class Net(nn.Module):
+    def __init__(self):
+        super(Net, self).__init__()
+        self.conv1 = nn.Conv2d(1, 32, 3, 1)
+        self.conv2 = nn.Conv2d(32, 64, 3, 1)
+        self.dropout1 = nn.Dropout(0.25)
+        self.dropout2 = nn.Dropout(0.5)
+        self.fc1 = nn.Linear(9216, 128)
+        self.fc2 = nn.Linear(128, 10)
+
+    def forward(self, x):
+        x = self.conv1(x)
+        x = F.relu(x)
+        x = self.conv2(x)
+        x = F.relu(x)
+        x = F.max_pool2d(x, 2)
+        x = self.dropout1(x)
+        x = torch.flatten(x, 1)
+        x = self.fc1(x)
+        x = F.relu(x)
+        x = self.dropout2(x)
+        x = self.fc2(x)
+        output = F.log_softmax(x, dim=1)
+        return output
+
+
+def train(args, model, rank, world_size, train_loader, optimizer, epoch, sampler=None):
+    model.train()
+    ddp_loss = torch.zeros(2).to(rank)
+    if sampler:
+        sampler.set_epoch(epoch)
+    for batch_idx, (data, target) in enumerate(train_loader):
+        data, target = data.to(rank), target.to(rank)
+        optimizer.zero_grad()
+        output = model(data)
+        loss = F.nll_loss(output, target, reduction='sum')
+        loss.backward()
+        optimizer.step()
+        ddp_loss[0] += loss.item()
+        ddp_loss[1] += len(data)
+
+    dist.reduce(ddp_loss, 0, op=dist.ReduceOp.SUM)
+    if rank == 0:
+        print('Train Epoch: {} \tLoss: {:.6f}'.format(epoch, ddp_loss[0] / ddp_loss[1]))
+
+
+def test(model, rank, world_size, test_loader):
+    model.eval()
+    correct = 0
+    ddp_loss = torch.zeros(3).to(rank)
+    with torch.no_grad():
+        for data, target in test_loader:
+            data, target = data.to(rank), target.to(rank)
+            output = model(data)
+            ddp_loss[0] += F.nll_loss(output, target, reduction='sum').item()  # sum up batch loss
+            pred = output.argmax(dim=1, keepdim=True)  # get the index of the max log-probability
+            ddp_loss[1] += pred.eq(target.view_as(pred)).sum().item()
+            ddp_loss[2] += len(data)
+
+    dist.reduce(ddp_loss, 0, op=dist.ReduceOp.SUM)
+
+    if rank == 0:
+        test_loss = ddp_loss[0] / ddp_loss[2]
+        print('Test set: Average loss: {:.4f}, Accuracy: {}/{} ({:.2f}%)\n'.format(
+            test_loss, int(ddp_loss[1]), int(ddp_loss[2]),
+            100. * ddp_loss[1] / ddp_loss[2]))
+
+
+def ddp_main(rank, world_size, args):
+    setup(rank, world_size)
+
+    transform = transforms.Compose([
+        transforms.ToTensor(),
+        transforms.Normalize((0.1307,), (0.3081,))
+    ])
+
+    dataset1 = datasets.MNIST('../data', train=True, download=True,
+                              transform=transform)
+    dataset2 = datasets.MNIST('../data', train=False,
+                              transform=transform)
+
+    sampler1 = DistributedSampler(dataset1, rank=rank, num_replicas=world_size, shuffle=True)
+    sampler2 = DistributedSampler(dataset2, rank=rank, num_replicas=world_size)
+
+    train_kwargs = {'batch_size': args.batch_size, 'sampler': sampler1}
+    test_kwargs = {'batch_size': args.test_batch_size, 'sampler': sampler2}
+    cuda_kwargs = {'num_workers': 2,
+                   'pin_memory': True,
+                   'shuffle': False}
+    train_kwargs.update(cuda_kwargs)
+    test_kwargs.update(cuda_kwargs)
+
+    train_loader = torch.utils.data.DataLoader(dataset1, **train_kwargs)
+    test_loader = torch.utils.data.DataLoader(dataset2, **test_kwargs)
+    my_auto_wrap_policy = functools.partial(
+        default_auto_wrap_policy, min_num_params=20000
+    )
+    torch.cuda.set_device(rank)
+
+    init_start_event = torch.cuda.Event(enable_timing=True)
+    init_end_event = torch.cuda.Event(enable_timing=True)
+
+    init_start_event.record()
+
+    model = Net().to(rank)
+
+    model = FSDP(model)
+
+    optimizer = optim.Adadelta(model.parameters(), lr=args.lr)
+
+    scheduler = StepLR(optimizer, step_size=1, gamma=args.gamma)
+
+    for epoch in range(1, args.epochs + 1):
+        train(args, model, rank, world_size, train_loader, optimizer, epoch, sampler=sampler1)
+        test(model, rank, world_size, test_loader)
+        scheduler.step()
+
+    init_end_event.record()
+
+    if rank == 0:
+        print(f"Cuda event elapsed time: {init_start_event.elapsed_time(init_end_event) / 1000}sec")
+        print(f"{model}")
+
+    if args.save_model:
+        dist.barrier()
+        states = model.state_dict()
+    if rank == 0:
+        torch.save(states, "mnist_cnn.pt")
+
+    cleanup()
+
+
+if __name__ == '__main__':
+    # Training settings
+    parser = argparse.ArgumentParser(description='PyTorch MNIST Example')
+    parser.add_argument('--batch-size', type=int, default=64, metavar='N',
+                        help='input batch size for training (default: 64)')
+    parser.add_argument('--test-batch-size', type=int, default=1000, metavar='N',
+                        help='input batch size for testing (default: 1000)')
+    parser.add_argument('--epochs', type=int, default=10, metavar='N',
+                        help='number of epochs to train (default: 14)')
+    parser.add_argument('--lr', type=float, default=1.0, metavar='LR',
+                        help='learning rate (default: 1.0)')
+    parser.add_argument('--gamma', type=float, default=0.7, metavar='M',
+                        help='Learning rate step gamma (default: 0.7)')
+    parser.add_argument('--no-cuda', action='store_true', default=False,
+                        help='disables CUDA training')
+    parser.add_argument('--seed', type=int, default=1, metavar='S',
+                        help='random seed (default: 1)')
+    parser.add_argument('--save-model', action='store_true', default=True,
+                        help='For Saving the current Model')
+    args = parser.parse_args()
+
+    torch.manual_seed(args.seed)
+
+    WORLD_SIZE = torch.cuda.device_count()
+    mp.spawn(ddp_main,
+             args=(WORLD_SIZE, args),
+             nprocs=WORLD_SIZE,
+             join=True)

--- a/training-job/mnist_fsdp.py
+++ b/training-job/mnist_fsdp.py
@@ -9,6 +9,7 @@ import torch.multiprocessing as mp
 import torch.nn as nn
 import torch.nn.functional as F
 import torch.optim as optim
+
 # from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
 from torch.distributed.fsdp.fully_sharded_data_parallel import (
     FullyShardedDataParallel as FSDP,
@@ -22,9 +23,6 @@ from torchvision import datasets, transforms
 
 
 def setup(rank, world_size):
-    os.environ['MASTER_ADDR'] = 'localhost'
-    os.environ['MASTER_PORT'] = '12355'
-
     # initialize the process group
     dist.init_process_group("nccl", rank=rank, world_size=world_size)
 
@@ -68,7 +66,7 @@ def train(args, model, rank, world_size, train_loader, optimizer, epoch, sampler
         data, target = data.to(rank), target.to(rank)
         optimizer.zero_grad()
         output = model(data)
-        loss = F.nll_loss(output, target, reduction='sum')
+        loss = F.nll_loss(output, target, reduction="sum")
         loss.backward()
         optimizer.step()
         ddp_loss[0] += loss.item()
@@ -76,7 +74,7 @@ def train(args, model, rank, world_size, train_loader, optimizer, epoch, sampler
 
     dist.reduce(ddp_loss, 0, op=dist.ReduceOp.SUM)
     if rank == 0:
-        print('Train Epoch: {} \tLoss: {:.6f}'.format(epoch, ddp_loss[0] / ddp_loss[1]))
+        print("Train Epoch: {} \tLoss: {:.6f}".format(epoch, ddp_loss[0] / ddp_loss[1]))
 
 
 def test(model, rank, world_size, test_loader):
@@ -87,7 +85,7 @@ def test(model, rank, world_size, test_loader):
         for data, target in test_loader:
             data, target = data.to(rank), target.to(rank)
             output = model(data)
-            ddp_loss[0] += F.nll_loss(output, target, reduction='sum').item()  # sum up batch loss
+            ddp_loss[0] += F.nll_loss(output, target, reduction="sum").item()  # sum up batch loss
             pred = output.argmax(dim=1, keepdim=True)  # get the index of the max log-probability
             ddp_loss[1] += pred.eq(target.view_as(pred)).sum().item()
             ddp_loss[2] += len(data)
@@ -96,40 +94,35 @@ def test(model, rank, world_size, test_loader):
 
     if rank == 0:
         test_loss = ddp_loss[0] / ddp_loss[2]
-        print('Test set: Average loss: {:.4f}, Accuracy: {}/{} ({:.2f}%)\n'.format(
-            test_loss, int(ddp_loss[1]), int(ddp_loss[2]),
-            100. * ddp_loss[1] / ddp_loss[2]))
+        print(
+            "Test set: Average loss: {:.4f}, Accuracy: {}/{} ({:.2f}%)\n".format(
+                test_loss, int(ddp_loss[1]), int(ddp_loss[2]), 100.0 * ddp_loss[1] / ddp_loss[2]
+            )
+        )
 
 
 def ddp_main(rank, world_size, args):
     setup(rank, world_size)
 
-    transform = transforms.Compose([
-        transforms.ToTensor(),
-        transforms.Normalize((0.1307,), (0.3081,))
-    ])
+    transform = transforms.Compose(
+        [transforms.ToTensor(), transforms.Normalize((0.1307,), (0.3081,))]
+    )
 
-    dataset1 = datasets.MNIST('../data', train=True, download=True,
-                              transform=transform)
-    dataset2 = datasets.MNIST('../data', train=False,
-                              transform=transform)
+    dataset1 = datasets.MNIST("../data", train=True, download=True, transform=transform)
+    dataset2 = datasets.MNIST("../data", train=False, transform=transform)
 
     sampler1 = DistributedSampler(dataset1, rank=rank, num_replicas=world_size, shuffle=True)
     sampler2 = DistributedSampler(dataset2, rank=rank, num_replicas=world_size)
 
-    train_kwargs = {'batch_size': args.batch_size, 'sampler': sampler1}
-    test_kwargs = {'batch_size': args.test_batch_size, 'sampler': sampler2}
-    cuda_kwargs = {'num_workers': 2,
-                   'pin_memory': True,
-                   'shuffle': False}
+    train_kwargs = {"batch_size": args.batch_size, "sampler": sampler1}
+    test_kwargs = {"batch_size": args.test_batch_size, "sampler": sampler2}
+    cuda_kwargs = {"num_workers": 2, "pin_memory": True, "shuffle": False}
     train_kwargs.update(cuda_kwargs)
     test_kwargs.update(cuda_kwargs)
 
     train_loader = torch.utils.data.DataLoader(dataset1, **train_kwargs)
     test_loader = torch.utils.data.DataLoader(dataset2, **test_kwargs)
-    my_auto_wrap_policy = functools.partial(
-        default_auto_wrap_policy, min_num_params=20000
-    )
+    my_auto_wrap_policy = functools.partial(default_auto_wrap_policy, min_num_params=20000)
     torch.cuda.set_device(rank)
 
     init_start_event = torch.cuda.Event(enable_timing=True)
@@ -165,31 +158,51 @@ def ddp_main(rank, world_size, args):
     cleanup()
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     # Training settings
-    parser = argparse.ArgumentParser(description='PyTorch MNIST Example')
-    parser.add_argument('--batch-size', type=int, default=64, metavar='N',
-                        help='input batch size for training (default: 64)')
-    parser.add_argument('--test-batch-size', type=int, default=1000, metavar='N',
-                        help='input batch size for testing (default: 1000)')
-    parser.add_argument('--epochs', type=int, default=10, metavar='N',
-                        help='number of epochs to train (default: 14)')
-    parser.add_argument('--lr', type=float, default=1.0, metavar='LR',
-                        help='learning rate (default: 1.0)')
-    parser.add_argument('--gamma', type=float, default=0.7, metavar='M',
-                        help='Learning rate step gamma (default: 0.7)')
-    parser.add_argument('--no-cuda', action='store_true', default=False,
-                        help='disables CUDA training')
-    parser.add_argument('--seed', type=int, default=1, metavar='S',
-                        help='random seed (default: 1)')
-    parser.add_argument('--save-model', action='store_true', default=True,
-                        help='For Saving the current Model')
+    parser = argparse.ArgumentParser(description="PyTorch MNIST Example")
+    parser.add_argument(
+        "--batch-size",
+        type=int,
+        default=64,
+        metavar="N",
+        help="input batch size for training (default: 64)",
+    )
+    parser.add_argument(
+        "--test-batch-size",
+        type=int,
+        default=1000,
+        metavar="N",
+        help="input batch size for testing (default: 1000)",
+    )
+    parser.add_argument(
+        "--epochs",
+        type=int,
+        default=10,
+        metavar="N",
+        help="number of epochs to train (default: 14)",
+    )
+    parser.add_argument(
+        "--lr", type=float, default=1.0, metavar="LR", help="learning rate (default: 1.0)"
+    )
+    parser.add_argument(
+        "--gamma",
+        type=float,
+        default=0.7,
+        metavar="M",
+        help="Learning rate step gamma (default: 0.7)",
+    )
+    parser.add_argument(
+        "--no-cuda", action="store_true", default=False, help="disables CUDA training"
+    )
+    parser.add_argument("--seed", type=int, default=1, metavar="S", help="random seed (default: 1)")
+    parser.add_argument(
+        "--save-model", action="store_true", default=True, help="For Saving the current Model"
+    )
     args = parser.parse_args()
 
     torch.manual_seed(args.seed)
 
-    WORLD_SIZE = torch.cuda.device_count()
-    mp.spawn(ddp_main,
-             args=(WORLD_SIZE, args),
-             nprocs=WORLD_SIZE,
-             join=True)
+    WORLD_SIZE = int(os.environ["WORLD_SIZE"])
+    rank = int(os.environ["LOCAL_RANK"])
+    ddp_main(rank, WORLD_SIZE, args)

--- a/training-job/requirements.txt
+++ b/training-job/requirements.txt
@@ -4,3 +4,4 @@ sklearn
 pytorch_lightning
 transformers
 torchdata
+torchvision


### PR DESCRIPTION
Signed-off-by: Shrinath Suresh <shrinath@ideas2it.com>

PyTorch Fully Sharded Data Parallel - https://pytorch.org/tutorials/intermediate/FSDP_tutorial.html 

This example trains MNIST dataset using PyTorch fsdp in a distributed environment.

The distributed training process is achieved using SLURM and Pytorch Elastic.

19/04:
Sample Slurm logs - [slurm_mnist.txt](https://github.com/chauhang/uber-prof/files/8510053/slurm_mnist.txt)


![Screenshot from 2022-04-19 10-43-16](https://user-images.githubusercontent.com/63862647/163925281-a546cd81-bfae-407a-8f65-0b06baf27f66.png)
![Screenshot from 2022-04-19 10-43-12](https://user-images.githubusercontent.com/63862647/163925286-83462c0b-73bf-4d21-aaf2-6fef9f6811c5.png)
 