### PR TITLE
Slurm file updates

### DIFF
--- a/training-job/bert.slurm
+++ b/training-job/bert.slurm
@@ -2,10 +2,11 @@
 ### e.g. request 4 nodes with 1 gpu each, totally 4 gpus (WORLD_SIZE==4)
 ### Note: --gres=gpu:x should equal to ntasks-per-node
 #SBATCH --nodes=2
-#SBATCH --ntasks-per-node=8
-#SBATCH --gres=gpu:8
+#SBATCH --ntasks-per-node=4
+#SBATCH --gres=gpu:4
 #SBATCH --mem=0
 #SBATCH --signal=SIGUSR1@90
+#SBATCH --cpus-per-task=8
 
 ### change 5-digit MASTER_PORT as you wish, slurm will raise Error if duplicated with others
 ### change WORLD_SIZE as gpus/node * num_nodes
@@ -39,5 +40,5 @@ export NCCL_SOCKET_IFNAME="en,eth,em,bond"
 
 ### the command to run
 dcgmi profile --pause
-srun --prolog job_prolog.sh --epilog job_epilog.sh /usr/local/cuda/bin/nsys profile -t cuda,nvtx -s none -x true python bert.py --strategy=ddp --num_nodes=2 --gpus=8 --max_epochs=15 --resume True
+srun --prolog job_prolog.sh --epilog job_epilog.sh /usr/local/cuda/bin/nsys profile -t cuda,nvtx -s none -x true python bert.py --strategy=ddp --num_nodes=2 --gpus=4 --max_epochs=15 --resume True
 dcgmi profile --resume

--- a/training-job/cifar.slurm
+++ b/training-job/cifar.slurm
@@ -4,6 +4,7 @@
 #SBATCH --nodes=2
 #SBATCH --mem=0
 #SBATCH --signal=SIGUSR1@90
+#SBATCH --cpus-per-task=32
 
 
 ### the command to run

--- a/training-job/mnist.slurm
+++ b/training-job/mnist.slurm
@@ -4,6 +4,7 @@
 #SBATCH --nodes=2
 #SBATCH --mem=0
 #SBATCH --signal=SIGUSR1@90
+#SBATCH --cpus-per-task=32
 
 
 ### the command to run


### PR DESCRIPTION
More speed up is observed during the training when cpu-per-task is set.

Here are the logs with and without cpu-per-task parameter for the bert example

[with cpu-per-task](https://gist.github.com/shrinath-suresh/3be50067cbbb0432116f8d4a45e1c962)
[without-cpu-per-task](https://gist.github.com/shrinath-suresh/0eae46470a5f812197eedad8e15aefb6)

per epoch training time reduced from 21 seconds to 6 seconds

Test logs for Cifar and mnist are below

[uber_prof_mnist.txt](https://github.com/chauhang/uber-prof/files/8778123/uber_prof_mnist.txt)
[uber_prof_cifar.txt](https://github.com/chauhang/uber-prof/files/8778124/uber_prof_cifar.txt)



