### PR TITLE
Pinning protobuf version to <=3.20.1

### DIFF
--- a/training-job/requirements.txt
+++ b/training-job/requirements.txt
@@ -6,3 +6,5 @@ transformers
 torchdata
 mosaicml
 torchvision
+protobuf<=3.20.1 #Remove once PTL supports latest protobuf - https://github.com/PyTorchLightning/pytorch-lightning/issues/13212
+


### PR DESCRIPTION
New version of protobuf has been released on May 28, 2022 - https://pypi.org/project/protobuf/4.21.1/

PTL only supports protobuf till 3.20.1. Hence, pinning the version to `<=3.20.1`.

Created a tracking issue in PTL to support new version - https://github.com/PyTorchLightning/pytorch-lightning/issues/13212