### PR TITLE
Utility to calculate inference time

### DIFF
--- a/training-job/tools/bert_test.py
+++ b/training-job/tools/bert_test.py
@@ -1,0 +1,35 @@
+from argparse import ArgumentParser
+from transformers import BertTokenizer, BertModel
+
+from calc_inference_time import calculate_inference_time
+
+if __name__ == "__main__":
+    parser = ArgumentParser(description="Calculate HF bert inference time")
+    parser.add_argument(
+        "--warm_up",
+        type=int,
+        default=10,
+        metavar="N",
+        help="number of iterations to warm up (default: 10)",
+    )
+
+    parser.add_argument(
+        "--n_repeat",
+        type=int,
+        default=100,
+        metavar="N",
+        help="number of inference request to calculate inference time (default: 100)",
+    )
+
+    args = parser.parse_args()
+
+    tokenizer = BertTokenizer.from_pretrained("bert-base-cased")
+    model = BertModel.from_pretrained("bert-base-cased")
+    text = "bloomberg has reported on the economy"
+    encoded_input = tokenizer(text, return_tensors="pt")
+    calculate_inference_time(
+        model=model,
+        inputs={"input_ids": encoded_input.input_ids},
+        warm_up=args.warm_up,
+        n_repeat=args.n_repeat,
+    )

--- a/training-job/tools/calc_inference_time.py
+++ b/training-job/tools/calc_inference_time.py
@@ -1,0 +1,45 @@
+import timeit
+
+import torch
+from tqdm import tqdm
+
+
+def calculate_inference_time(
+    model, inputs, warm_up: int, n_repeat: int, profiler: bool = True, profiler_args: dict = None
+):
+    for _ in tqdm(range(warm_up)):
+        if isinstance(inputs, dict):
+            _ = model(**inputs)
+        else:
+            _ = model(inputs)
+
+    print("Calculating average time taken for inference")
+
+    mean_inference_time = 0
+    if profiler:
+        if profiler_args is None:
+            profiler_args = {
+                "activities": [
+                    torch.profiler.ProfilerActivity.CPU,
+                    torch.profiler.ProfilerActivity.CUDA,
+                ],
+                "on_trace_ready": torch.profiler.tensorboard_trace_handler("./logs"),
+            }
+        with torch.profiler.profile(**profiler_args) as prof:
+            for _ in tqdm(range(n_repeat)):
+                if isinstance(inputs, dict):
+                    mean_inference_time += timeit.timeit(lambda: model(**inputs), number=1)
+                else:
+                    mean_inference_time += timeit.timeit(lambda: model(inputs), number=1)
+                prof.step()
+    else:
+        for _ in tqdm(range(n_repeat)):
+            if isinstance(inputs, dict):
+                mean_inference_time += timeit.timeit(lambda: model(**inputs), number=1)
+            else:
+                mean_inference_time += timeit.timeit(lambda: model(inputs), number=1)
+
+    mean_inference_time = round(mean_inference_time / n_repeat, 2)
+    print("Avg time taken for inference: ", mean_inference_time)
+
+    return mean_inference_time


### PR DESCRIPTION
Created a new utility to calculate inference time and added an example

Utility takes following arguments

```
def calculate_inference_time(
    model, inputs, warm_up: int, n_repeat: int, profiler: bool = False, profiler_args: dict = None
):
```

model - pytorch model
inputs - input to be passed to the model (tensor)
warm_up - number of iterations for warm_up stage
n_repeat - number of iteration for inference
profiler - bool variable to toggle profiling
profiler_args - in case user wants to pass custom parameters to profiler
